### PR TITLE
BUG: Fix incorrect Markup name in Markups module

### DIFF
--- a/GridSurfaceMarkups/MRML/vtkMRMLMarkupsGridSurfaceNode.h
+++ b/GridSurfaceMarkups/MRML/vtkMRMLMarkupsGridSurfaceNode.h
@@ -71,8 +71,11 @@ public:
   ///
   const char* GetNodeTagName() override {return "MarkupsGridSurface";}
 
-  /// Get markup name
+  /// Get markup type internal name
   const char* GetMarkupType() override {return "GridSurface";}
+
+  // Get markup type GUI display name
+  const char* GetMarkupTypeDisplayName() override {return "Grid Surface";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "GS";}


### PR DESCRIPTION
`GetMarkupTypeDisplayName` was added in https://github.com/Slicer/Slicer/commit/6de76971b2b82644ce24896b49e36b69b2fcf1a1.

| Current | Current with Slicer PR https://github.com/Slicer/Slicer/pull/6057 | This PR |
|----------|-------------------------|---------|
|![image](https://user-images.githubusercontent.com/15837524/144295900-ab86523e-7122-4f10-9756-db8274b8779a.png)|![image](https://user-images.githubusercontent.com/15837524/144297424-48736236-e4bf-4051-8464-920e77b0ae48.png)|![image](https://user-images.githubusercontent.com/15837524/144297540-c20f60e3-4586-4303-a3d7-81666ec0d16b.png)|